### PR TITLE
feat: add freshUrls to SitemapUrl and update sitemap processing logic

### DIFF
--- a/src/shop-product/shop-product.service.ts
+++ b/src/shop-product/shop-product.service.ts
@@ -441,7 +441,7 @@ export class ShopProductService {
       if (!shopProduct) continue;
 
       const reducedSitemap = this.shopService.reduceSitemap(
-        shopProduct.shop.sitemapEntity.sitemapUrl.urls,
+        shopProduct.shop.sitemapEntity.sitemapUrl.freshUrls,
         shopProduct.product.name,
       );
 
@@ -449,6 +449,7 @@ export class ShopProductService {
         this.logger.error({
           shopProductId: shopProduct.id,
           error: `reducedSitemap.length === 0`,
+          freshUrls: shopProduct.shop.sitemapEntity.sitemapUrl.freshUrls.length,
         });
       }
 

--- a/src/sitemap-url/entities/sitemap-url.entity.ts
+++ b/src/sitemap-url/entities/sitemap-url.entity.ts
@@ -17,6 +17,9 @@ export class SitemapUrl {
   @Column({ type: 'simple-array', default: '' })
   urls: string[];
 
+  @Column({ type: 'simple-array', default: '' })
+  freshUrls: string[];
+
   @OneToOne(() => Sitemap, (sitemap) => sitemap.sitemapUrl, {
     onDelete: 'CASCADE',
   })

--- a/src/sitemap/sitemap.service.ts
+++ b/src/sitemap/sitemap.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
 import { CreateSitemapDto } from './dto/create-sitemap.dto';
 import { UpdateSitemapDto } from './dto/update-sitemap.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -10,6 +10,7 @@ import { SitemapUrl } from 'src/sitemap-url/entities/sitemap-url.entity';
 
 @Injectable()
 export class SitemapService {
+  private logger = new Logger(SitemapService.name);
   constructor(
     @InjectRepository(Sitemap) private sitemapRepository: Repository<Sitemap>,
     @InjectRepository(SitemapUrl)
@@ -93,13 +94,14 @@ export class SitemapService {
   async checkSiteMapLoop(
     sitemapEntity: Sitemap,
     updateSitemapDto: UpdateSitemapDto,
-  ): Promise<boolean> {
+  ): Promise<{ unchanged: boolean; newUrls: string[] }> {
+    const newUrls: string[] = [];
+    let unchanged = true;
     if (
-      sitemapEntity.sitemapUrl?.urls?.length !==
+      sitemapEntity.sitemapUrl?.urls?.length ===
       updateSitemapDto.sitemapUrls.length
     )
-      return false;
-    console.time('checkSites');
+      return { unchanged: false, newUrls };
 
     const dbUrls = new Set(sitemapEntity.sitemapUrl.urls);
 
@@ -107,8 +109,12 @@ export class SitemapService {
       const url = updateSitemapDto.sitemapUrls[i];
 
       if (!dbUrls.has(url)) {
-        console.timeEnd('checkSites');
-        return false;
+        newUrls.push(url);
+
+        this.logger.debug(`new url: ${url}`);
+        // await new Promise((r) => setTimeout(r, 20000));
+
+        unchanged = false;
       }
 
       if ((i + 1) % 10_000 === 0) {
@@ -118,8 +124,7 @@ export class SitemapService {
     }
 
     console.log('✅ Done checking, result is: ', true);
-    console.timeEnd('checkSites');
-    return true;
+    return { unchanged, newUrls };
   }
 
   async checkSiteMap(
@@ -129,15 +134,18 @@ export class SitemapService {
     const sitemapEntity = await this.findOne(id);
     console.log('checking sitemap urls');
     console.time('checkSites');
-    let sameSites = true;
 
-    sameSites = await this.checkSiteMapLoop(sitemapEntity, updateSitemapDto);
+    const sameSites = await this.checkSiteMapLoop(
+      sitemapEntity,
+      updateSitemapDto,
+    );
     console.log(sameSites);
 
-    if (!sameSites) {
+    if (!sameSites.unchanged) {
       console.log(sitemapEntity.sitemapUrl.id);
       await this.sitemapUrlRepository.update(sitemapEntity.sitemapUrl.id, {
         urls: updateSitemapDto.sitemapUrls || [''],
+        freshUrls: sameSites.newUrls,
       });
       await this.update(id, {
         ...updateSitemapDto,


### PR DESCRIPTION
Looks at the URLS to see if new urls exist. If new urls exist, check to see if they pass reduction tests. If they do, URLs qualify to be ranked. Prevents old urls being reranked unless we absolutely want to "delete sitemapUrls"